### PR TITLE
Make *pages just work

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,5 +18,6 @@ Depends:
     shiny
 Suggests:
     covr,
+    htmltools,
     testthat
 RoxygenNote: 6.0.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ### crunchy 0.2.3 (under development)
+* Support for all `shiny::bootstrapPage()` types directly: no need for a `crunch-`prefixed version of them. Now you can use `navbarPage`, `fillPage`, etc. just as you would for any `shiny` app, and when the `crunchy` package is loaded, Crunch authentication and other enhancements will automatically be loaded.
 
 ### crunchy 0.2.2
 

--- a/R/crunch-page.R
+++ b/R/crunch-page.R
@@ -5,7 +5,9 @@
 #' Crunch UI style and keep your users authenticated. When building shiny apps
 #' with Crunch datasets, use these instead of [shiny::fluidPage()],
 #' [shiny::fillPage()] or [shiny::navbarPage()].
-#' @param title the title to be displayed in the navigation bar. Defaults to NULL.
+#'
+#' These are no longer necessary. Just use the `shiny` ones and it just works.
+#' These functions are left here for backwards compatibility.
 #' @param ... arguments passed to `fluidPage`, `fillPage` or `navbarPage`
 #' @return The result of `fluidPage`, `fillPage` or `navbarPage`
 #' @export
@@ -33,13 +35,7 @@
 #'     )
 #' )
 #' }
-crunchPage <- function (...) {
-    fluidPage(
-        loadCrunchAssets(),
-        crunchAuthPlaceholder(),
-        ...
-    )
-}
+crunchPage <- function (...) fluidPage(...)
 
 #' @rdname crunchPage
 #' @export
@@ -47,37 +43,8 @@ crunchFluidPage <- crunchPage
 
 #' @rdname crunchPage
 #' @export
-crunchFillPage <- function (...) {
-    fillPage(
-        loadCrunchAssets(),
-        crunchAuthPlaceholder(),
-        ...
-    )
-}
+crunchFillPage <- function (...) fillPage(...)
 
 #' @rdname crunchPage
 #' @export
-crunchNavbarPage <- function(title = NULL, ...) {
-  navbarPage(title = title,
-    loadCrunchAssets(),
-    crunchAuthPlaceholder(),
-    ...
-  )
-}
-
-#' @importFrom shiny includeCSS includeScript tags
-loadCrunchAssets <- function () {
-    tags$head(
-        tags$link(rel="stylesheet", type="text/css",
-            href="https://app.crunch.io/styles.css"),
-        includeCSS(system.file("extra.css", package="crunchy")),
-        includeScript(system.file("extra.js", package="crunchy"))
-    )
-}
-
-#' @importFrom shiny div
-crunchAuthPlaceholder <- function () {
-    div(class = "form-group shiny-input-container",
-        style = "display: none;",
-        tags$input(id = "token", type = "text", class = "form-control", value = ""))
-}
+crunchNavbarPage <- function (...) navbarPage(...)

--- a/R/crunch-page.R
+++ b/R/crunch-page.R
@@ -48,3 +48,50 @@ crunchFillPage <- function (...) fillPage(...)
 #' @rdname crunchPage
 #' @export
 crunchNavbarPage <- function (...) navbarPage(...)
+
+#' @importFrom shiny div includeCSS includeScript tags
+injectCrunchAssets <- function () {
+    suppressMessages(
+        trace(
+            "bootstrapPage",
+            where=shiny::fillPage,
+            tracer=crunchAssets,
+            print=FALSE
+        )
+    )
+}
+
+crunchAssets <- quote({
+    attachDependencies <- function (x, ...) {
+        # Prepend a bit of HTML before whatever the user supplied but after
+        # the global things--as if these were the first things in the user's
+        # list
+        x[[length(x)]] <- c(
+            list(
+                # Load Crunch assets
+                tags$head(
+                    tags$link(
+                        rel="stylesheet",
+                        type="text/css",
+                        href="https://app.crunch.io/styles.css"
+                    ),
+                    includeCSS(system.file("extra.css", package="crunchy")),
+                    includeScript(system.file("extra.js", package="crunchy"))
+                ),
+                # Add a placeholder for Crunch auth
+                div(
+                    class = "form-group shiny-input-container",
+                    style = "display: none;",
+                    tags$input(
+                        id = "token",
+                        type = "text",
+                        class = "form-control",
+                        value = ""
+                    )
+                )
+            ),
+            x[[length(x)]]
+        )
+        htmltools::attachDependencies(x, ...)
+    }
+})

--- a/R/crunchy.R
+++ b/R/crunchy.R
@@ -1,23 +1,4 @@
-#' @importFrom shiny div includeCSS includeScript tags
 .onLoad <- function (lib, pkgname="crunchy") {
-    suppressMessages(trace("bootstrapPage", where=shiny::fillPage, tracer=quote({
-        tagList <- function (...) {
-            shiny::tagList(
-                ...,
-                # Load our assets
-                tags$head(
-                    tags$link(rel="stylesheet", type="text/css",
-                        href="https://app.crunch.io/styles.css"),
-                    includeCSS(system.file("extra.css", package="crunchy")),
-                    includeScript(system.file("extra.js", package="crunchy"))
-                ),
-                # Add a placeholder for our auth
-                div(class = "form-group shiny-input-container",
-                    style = "display: none;",
-                    tags$input(id = "token", type = "text", class = "form-control", value = "")
-                )
-            )
-        }
-    }), print=FALSE))
+    injectCrunchAssets()
     invisible()
 }

--- a/R/crunchy.R
+++ b/R/crunchy.R
@@ -1,0 +1,23 @@
+#' @importFrom shiny div includeCSS includeScript tags
+.onLoad <- function (lib, pkgname="crunchy") {
+    suppressMessages(trace("bootstrapPage", where=shiny::fillPage, tracer=quote({
+        tagList <- function (...) {
+            shiny::tagList(
+                ...,
+                # Load our assets
+                tags$head(
+                    tags$link(rel="stylesheet", type="text/css",
+                        href="https://app.crunch.io/styles.css"),
+                    includeCSS(system.file("extra.css", package="crunchy")),
+                    includeScript(system.file("extra.js", package="crunchy"))
+                ),
+                # Add a placeholder for our auth
+                div(class = "form-group shiny-input-container",
+                    style = "display: none;",
+                    tags$input(id = "token", type = "text", class = "form-control", value = "")
+                )
+            )
+        }
+    }), print=FALSE))
+    invisible()
+}

--- a/man/crunchPage.Rd
+++ b/man/crunchPage.Rd
@@ -13,12 +13,10 @@ crunchFluidPage(...)
 
 crunchFillPage(...)
 
-crunchNavbarPage(title = NULL, ...)
+crunchNavbarPage(...)
 }
 \arguments{
 \item{...}{arguments passed to `fluidPage`, `fillPage` or `navbarPage`}
-
-\item{title}{the title to be displayed in the navigation bar. Defaults to NULL.}
 }
 \value{
 The result of `fluidPage`, `fillPage` or `navbarPage`
@@ -29,6 +27,10 @@ functions wraps those and includes additional assets needed to match
 Crunch UI style and keep your users authenticated. When building shiny apps
 with Crunch datasets, use these instead of [shiny::fluidPage()],
 [shiny::fillPage()] or [shiny::navbarPage()].
+}
+\details{
+These are no longer necessary. Just use the `shiny` ones and it just works.
+These functions are left here for backwards compatibility.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-page.R
+++ b/tests/testthat/test-page.R
@@ -13,7 +13,13 @@ test_that("crunchFillPage has a token div", {
 })
 
 test_that("crunchNavbarPage has a token div", {
-    cfp <- crunchNavbarPage()
-    out <- format(cfp)
+    cnp <- crunchNavbarPage("title")
+    out <- format(cnp)
+    expect_true(grepl('input id="token"', out))
+})
+
+test_that("shiny::fillPage has a token div", {
+    fp <- fillPage()
+    out <- format(fp)
     expect_true(grepl('input id="token"', out))
 })

--- a/tests/testthat/test-page.R
+++ b/tests/testthat/test-page.R
@@ -23,3 +23,15 @@ test_that("shiny::fillPage has a token div", {
     out <- format(fp)
     expect_true(grepl('input id="token"', out))
 })
+
+test_that("shiny::fillPage has a token div and whatever else we give it", {
+    fp <- fillPage(div(class="testing"))
+    out <- unlist(strsplit(format(fp), "\n"))
+    expect_true(any(grepl('input id="token"', out)))
+    expect_true(any(grepl('class="testing"', out)))
+    ## And our stuff is before any content the user provides
+    expect_true(grep('class="testing"', out) > grep('input id="token"', out))
+})
+
+## Obviously this is called in .onLoad, but call it here so covr sees it
+injectCrunchAssets()


### PR DESCRIPTION
Use `trace` to inject our `<head>` tags into any `shiny::bootstrapPage` flavor. Lets users just use the UI elements they're used to using with shiny, and keeps us from having to wrap every new *page that is created. 

One potential risk is that this couples us to the internals of that `bootstrapPage` function, but from what I can tell, this is using functions that are very stable, so I think the risk is low.