### PR TITLE
Skip shinytest tests on CRAN

### DIFF
--- a/tests/testthat/test-gadgets.R
+++ b/tests/testthat/test-gadgets.R
@@ -74,6 +74,7 @@ with_mock_crunch({
         expect_equivalent(names(l), "ds")
     })
     test_that("generateCategoryCheckboxes produces correct HTML", {
+        skip_on_cran()
         tag <- generateCategoryCheckboxes(ds, "location", "Multiple Response")
         expected_html <- c(
             "<div id=\"mr_selection\" class=\"form-group shiny-input-checkboxgroup shiny-input-container\">",


### PR DESCRIPTION
[These unit tests](https://github.com/Crunch-io/crunchy/compare/master...cpsievert:shiny-1.6?expand=1#diff-ad65c1aaebd3a4ad614f75c8f37301c96121bdd90d538c98b7799dbf672011e3R76-R100) make strong assumptions about the HTML markup that Shiny generates, and those assumptions will no longer be true when Shiny v1.6 is submitted to CRAN in the next couple weeks (and, as a result, you'll need to submit a new version to CRAN to fix this)

I strongly recommend skipping these tests on CRAN (as you're already doing with your shinytest tests) and updating the `expected_html` to accommodate for the next release of shiny, which you can install this way:

```r
remotes::install_github("rstudio/shiny")
```


